### PR TITLE
feat: simpler implementation

### DIFF
--- a/examples/hello-world/src/implementation.test.ts
+++ b/examples/hello-world/src/implementation.test.ts
@@ -2,9 +2,9 @@ import { expect, test } from 'vitest';
 import { helloImpl } from './implementation.js';
 
 test('default message', async () => {
-  expect(await helloImpl.testClient().hello({ message: undefined })).toEqual('Hello world');
+  expect(await helloImpl.implementation.hello({ message: undefined })).toEqual('Hello world');
 });
 
 test('specific message', async () => {
-  expect(await helloImpl.testClient().hello({ message: 'Joe!' })).toEqual('Hello Joe!');
+  expect(await helloImpl.implementation.hello({ message: 'Joe!' })).toEqual('Hello Joe!');
 });

--- a/examples/hello-world/src/implementation.ts
+++ b/examples/hello-world/src/implementation.ts
@@ -2,7 +2,7 @@ import { a } from '@apimda/core';
 import { createAwsLambdaHandler } from '@apimda/server';
 import { helloController } from './definition.js';
 
-export const helloImpl = a.implement(helloController).as({
+export const helloImpl = a.implement(helloController, {
   hello: async ({ message }) => `Hello ${message ?? 'world'}`
 });
 

--- a/integration-test/src/node-integration.test.ts
+++ b/integration-test/src/node-integration.test.ts
@@ -9,8 +9,9 @@ import { testControllerDef, testControllerImpl } from './test-controller.js';
 let server: Server;
 let client: InferControllerClientType<typeof testControllerDef>;
 
-beforeAll(() => {
-  server = createServer({ keepAliveTimeout: 1 }, createRequestListener({}, testControllerImpl));
+beforeAll(async () => {
+  const listener = await createRequestListener({}, testControllerImpl);
+  server = createServer({ keepAliveTimeout: 1 }, listener);
   server.listen();
 });
 

--- a/integration-test/src/playground.ts
+++ b/integration-test/src/playground.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { createFetchClient } from '@apimda/client';
-import { InferControllerClientType, a } from '@apimda/core';
+import { a } from '@apimda/core';
 import { createRequestListener } from '@apimda/server';
 import { createServer } from 'http';
 import { z } from 'zod';
@@ -44,32 +44,32 @@ const definition = a.controller('/path').define({
     .build() //async ({ first, second }) => first + second
 });
 
-const createContext = async () => {
-  return {
-    greeting: 'Hi'
-  };
-};
+const implementation = a.implement(
+  definition,
+  (() => {
+    const ctx = {
+      greeting: 'Hi'
+    };
 
-const implementation = a.implement(definition, createContext).as({
-  greet: async ({ name, age }, ctx) => `${ctx.greeting} ${name}, age: ${age}`,
+    return {
+      greet: async ({ name, age }) => `${ctx.greeting} ${name}, age: ${age}`,
 
-  hello: async () => 'Hi Joe!',
+      hello: async () => 'Hi Joe!',
 
-  log: async () => console.log('Hi Joe!'),
+      log: async () => console.log('Hi Joe!'),
 
-  outputSchema: async () => 'my card or whatever',
+      outputSchema: async () => 'my card or whatever',
 
-  echoObject: async ({ data }) => data,
+      echoObject: async ({ data }) => data,
 
-  echoText: async ({ data }) => data,
+      echoText: async ({ data }) => data,
 
-  echoBinary: async ({ data }) => data,
+      echoBinary: async ({ data }) => data,
 
-  add: async ({ first, second }) => first + second
-});
-
-type opType3 = InferControllerClientType<typeof definition>;
-//   ^?
+      add: async ({ first, second }) => first + second
+    };
+  })()
+);
 
 console.log(`Starting HTTP server...`);
 const listener = createRequestListener({}, implementation);
@@ -84,86 +84,17 @@ const client = createFetchClient(definition, 'http://localhost:8080');
 type clientType = typeof client;
 //    ^?
 
-(async () => {
-  const response = await client.greet({ name: 'me', age: 18 });
-  console.log(response);
+const response = await client.greet({ name: 'me', age: 18 });
+console.log(response);
 
-  const textResponse = await client.echoText({ data: 'some text' });
-  console.log(textResponse);
+const textResponse = await client.echoText({ data: 'some text' });
+console.log(textResponse);
 
-  const objResponse = await client.echoObject({ data: {} });
-  console.log(objResponse);
+const objResponse = await client.echoObject({ data: {} });
+console.log(objResponse);
 
-  const blob = new Blob(['hello from blob-land']);
-  const binaryResponse = await client.echoBinary({ data: blob });
-  console.log(await binaryResponse.text());
+const blob = new Blob(['hello from blob-land']);
+const binaryResponse = await client.echoBinary({ data: blob });
+console.log(await binaryResponse.text());
 
-  server.close();
-})();
-
-/*
- APIMDA default content-type:
-  -> if string return text/plain
-  -> if buffer return application/octet-stream
-  -> if object return application/json
-
-  ...use .setContentType(contentType) to specify content-type
-  ...or ApimdaResult<T> for custom response (but if content-type header is NOT specified, use defaults)
-    -> should ApimdaResult<T> be a class ...???  TODO: think about branding ApimdaResult<T>
-    -> ...maybe factory function, e.g. return apimdaResult(result, {statusCode?, headers?, cookies?})
-
-
-  OLD ideas:
-  interface MyContext {
-    hello: string;
-  }
-
-
-  const myController = controller<MyContext>({
-    hello: get('/hello')
-      .input({
-          name: query(z.string()),
-          age: query()
-      })
-      .output(text('text/plain'))
-      .build(({name, age}, context) => `${context.hello} ${name}, age: ${age}`)
-    })
-  }).build(); 
-
-
-  const myControllerDef = controller({
-    hello: get('/hello')
-      .input({
-        name: query(z.string()),
-        age: query()
-      })
-      .output(text('text/plain'))
-    })
-  ).buildDef(); 
-
-
-  const myController = controller<MyContext>(method => ({
-    hello: method.get('/hello')
-      .input(in => ({
-        name: in.query(z.string()),
-        age: in.query()
-      }))
-      .output(out => out.text('text/plain'))
-      .build(({name, age}, context) => `${context.hello} ${name}, age: ${age}`)
-  })).build(); 
-
-
-
-
-  .output(schema({
-    name: query(z.string().uuid()),
-    age: query(z.number().min(30))
-  }))
-  .output(binary('image/png'))
-  .output(text('text/html'))
-  .output(binary('image/png'), {
-    statusCode?: HttpSuccessStatusCode | HttpRedirectStatusCode;
-    headers?: Record<string, string | boolean | number>;
-    cookies?: Record<string, string | boolean | number>;
-  })
-*/
+server.close();

--- a/integration-test/src/test-controller.ts
+++ b/integration-test/src/test-controller.ts
@@ -115,7 +115,7 @@ export const testControllerDef = a.controller('/base').define({
     .build()
 });
 
-export const testControllerImpl = a.implement(testControllerDef).as({
+export const testControllerImpl = a.implement(testControllerDef, {
   bodyArrayExample: async input => input.body,
   bodyBinaryExample: async input => input.body,
   bodyObjectExample: async input => input.body,

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -3,15 +3,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 import {
+  AnyControllerImpl,
   AnyInputDef,
-  AnyOperationDef,
   AnyOutputDef,
   BinaryOutputDef,
   BodyBinaryParamDef,
   BodyTextParamDef,
   ControllerDef,
-  ControllerOperations,
-  InferControllerClientType,
   InferControllerImplType,
   JsonOutputDef,
   OperationDef,
@@ -126,31 +124,13 @@ function controller(basePath = '/') {
   };
 }
 
-function implement<TDef, TContext = unknown>(definition: TDef, createContext?: () => Promise<TContext>) {
+function implement<TDefinition extends ControllerDef>(
+  definition: TDefinition,
+  implementation: InferControllerImplType<TDefinition>
+): AnyControllerImpl {
   return {
-    as(impl: InferControllerImplType<typeof definition, TContext>) {
-      const operations: ControllerOperations = {};
-      for (const opName in definition) {
-        operations[opName] = {
-          def: definition[opName] as AnyOperationDef,
-          impl: impl[opName]
-        };
-      }
-      return {
-        operations,
-        createContext,
-        testClient(context?: TContext) {
-          // TODO testClient should probably be moved into server package to take advantage of all of the validation
-          const testClient: Record<string, Function> = {};
-          for (const opName in definition) {
-            testClient[opName] = (input: any) => {
-              return operations[opName].impl(input, context);
-            };
-          }
-          return testClient as InferControllerClientType<typeof definition>;
-        }
-      };
-    }
+    definition,
+    implementation
   };
 }
 

--- a/packages/server/src/lambda/lambda-runtime.test.ts
+++ b/packages/server/src/lambda/lambda-runtime.test.ts
@@ -66,15 +66,15 @@ const def1 = a.controller('/greeter').define({
   hello: a.op.get('/hello').output(a.out.object()).build()
 });
 
-const impl1 = a.implement(def1).as({ hello: async () => greeting });
+const impl1 = a.implement(def1, { hello: async () => greeting });
 
 const def2 = a.controller('/boo').define({
   yeah: a.op.get('/yo').output(a.out.text()).build()
 });
 
-const impl2 = a.implement(def2).as({ yeah: async () => 'hell yeah' });
+const impl2 = a.implement(def2, { yeah: async () => 'hell yeah' });
 
-const handler = createAwsLambdaHandler(impl1, impl2);
+const handler = await createAwsLambdaHandler(impl1, impl2);
 
 describe('createAwsLambdaHandler tests', () => {
   test('missing route', async () => {
@@ -87,7 +87,7 @@ describe('createAwsLambdaHandler tests', () => {
     });
   });
 
-  test('createAwsLambdaHandler w/out context', async () => {
+  test('createAwsLambdaHandler', async () => {
     const event = { routeKey: 'GET /greeter/hello' };
     const result = await handler(event as Event);
     expect(result).toEqual({

--- a/packages/server/src/node/node-runtime.test.ts
+++ b/packages/server/src/node/node-runtime.test.ts
@@ -10,9 +10,9 @@ const def = a.controller('/greeter').define({
   hello: a.op.get('/hello').output(a.out.object()).build()
 });
 
-const impl = a.implement(def).as({ hello: async () => greeting });
-
-const server = createServer(createRequestListener({}, impl));
+const impl = a.implement(def, { hello: async () => greeting });
+const listener = createRequestListener({}, impl);
+const server = createServer(listener);
 
 describe('createRequestListener tests', () => {
   test('missing route', async () => {


### PR DESCRIPTION
Simplifies `a.implement(...)` by removing context.  Apimda only needs an instance of an implementation - it doesn't care how it is constructed.

With top-level await, this makes using controllers in lambda handlers or elsewhere incredibly simple.

It also enables using classes for implementation, which I personally find more natural.