### PR TITLE
fix: remove test and map files from publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "name": "@apimda/apimda2",
-  "version": "0.0.5",
   "scripts": {
     "build": "tsc --build && pnpm run -r build",
     "cdk-deploy": "pnpm run build && pnpm --filter @apimda/example-hello-world run cdk-deploy",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@apimda/client",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "dist/index.js",
   "files": [
-    "/dist"
+    "/dist",
+    "!/**/*.map",
+    "!/**/*.test.*"
   ],
   "dependencies": {
     "@apimda/core": "workspace:*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@apimda/core",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "dist/index.js",
   "files": [
-    "/dist"
+    "/dist",
+    "!/**/*.map",
+    "!/**/*.test.*"
   ],
   "scripts": {
     "build": "tsc --build"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@apimda/server",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "dist/index.js",
   "files": [
-    "/dist"
+    "/dist",
+    "!/**/*.map",
+    "!/**/*.test.*"
   ],
   "dependencies": {
     "@apimda/core": "workspace:*",


### PR DESCRIPTION
- Removes test and source map files from the published NPM packages.
- Bumps package.json to v0.0.6 for next publish