### PR TITLE
fix: bigint support

### DIFF
--- a/integration-test/src/node-integration.test.ts
+++ b/integration-test/src/node-integration.test.ts
@@ -77,7 +77,8 @@ test('pathExample', async () => {
   const input = {
     bln: true,
     str: 'some text',
-    num: -120
+    num: -120,
+    bInt: BigInt(Number.MAX_SAFE_INTEGER) + 2n
   };
   expect(await client.pathExample(input)).toEqual(input);
 });
@@ -87,6 +88,7 @@ test('queryExample', async () => {
     bln: true,
     str: 'some text',
     num: -120,
+    bInt: BigInt(Number.MAX_SAFE_INTEGER) + 2n,
     obj: { id: 0 },
     optional: undefined
   };

--- a/integration-test/src/test-controller.ts
+++ b/integration-test/src/test-controller.ts
@@ -80,14 +80,16 @@ export const testControllerDef = a.controller('/base').define({
     .input({
       bln: a.in.path(z.boolean()),
       str: a.in.path(z.string()),
-      num: a.in.path(z.number())
+      num: a.in.path(z.number()),
+      bInt: a.in.query(z.bigint())
     })
     .output(
       a.out.schema(
         z.object({
           bln: z.boolean(),
           str: z.string(),
-          num: z.number()
+          num: z.number(),
+          bInt: z.coerce.bigint()
         })
       )
     )
@@ -99,6 +101,7 @@ export const testControllerDef = a.controller('/base').define({
       bln: a.in.query(z.boolean()),
       str: a.in.query(z.string()),
       num: a.in.query(z.number()),
+      bInt: a.in.query(z.bigint()),
       obj: a.in.query(z.object({ id: z.number() })),
       optional: a.in.query(z.string().optional())
     })
@@ -108,6 +111,7 @@ export const testControllerDef = a.controller('/base').define({
           bln: z.boolean(),
           str: z.string(),
           num: z.number(),
+          bInt: z.coerce.bigint(),
           obj: z.object({ id: z.number() }),
           optional: z.string().optional()
         })

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
     "package.json": "prettier-package-json --write",
     "*.ts": "eslint"
   },
-  "packageManager": "pnpm@8.6.3"
+  "packageManager": "pnpm@8.6.6"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/client",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/packages/client/src/client-utils.ts
+++ b/packages/client/src/client-utils.ts
@@ -46,11 +46,13 @@ export function buildHeaders(headers: Record<string, string>, cookies: Record<st
 }
 
 export type HeadParamLocation = Exclude<ParamLocation, 'body' | 'body-text' | 'body-binary'>;
-export type StringifiedParamValue = number | boolean | string | object;
+export type StringifiedParamValue = number | boolean | string | bigint | object;
 
 export function paramStringValue(value: StringifiedParamValue) {
   if (typeof value === 'string') {
     return value;
+  } else if (typeof value === 'bigint') {
+    return value.toString();
   }
   return JSON.stringify(value);
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,7 +15,7 @@ export type AnySerializedType = string | Binary;
 // Input
 // ------
 
-export type AnyParamType = undefined | boolean | number | object | string | Binary;
+export type AnyParamType = undefined | boolean | number | object | string | bigint | Binary;
 export type ParamLocation = 'body' | 'cookie' | 'header' | 'query' | 'path';
 
 export abstract class ParamDef<TParam extends AnyParamType, TSerialized extends AnySerializedType> {

--- a/packages/core/src/zod-utils.test.ts
+++ b/packages/core/src/zod-utils.test.ts
@@ -48,6 +48,20 @@ describe('preParseString', () => {
     expect(preParseString(ZodFirstPartyTypeKind.ZodEnum, 'true')).toBe('true');
     expect(preParseString(ZodFirstPartyTypeKind.ZodEnum, '1')).toBe('1');
   });
+  test('bigint schema', () => {
+    const biggerThanNumber = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+    expect(preParseString(ZodFirstPartyTypeKind.ZodBigInt, biggerThanNumber.toString())).toBe(biggerThanNumber);
+    expect(preParseString(ZodFirstPartyTypeKind.ZodBigInt, '1')).toBe(1n);
+    expect(() => {
+      preParseString(ZodFirstPartyTypeKind.ZodBigInt, 'true');
+    }).toThrow();
+    expect(() => {
+      preParseString(ZodFirstPartyTypeKind.ZodBigInt, 'undefined');
+    }).toThrow();
+    expect(() => {
+      preParseString(ZodFirstPartyTypeKind.ZodBigInt, '1.02');
+    }).toThrow();
+  });
   test('boolean schema', () => {
     assertJsonPreParse(ZodFirstPartyTypeKind.ZodBoolean);
   });

--- a/packages/core/src/zod-utils.ts
+++ b/packages/core/src/zod-utils.ts
@@ -16,7 +16,7 @@ export function extractTypeName(s: ZodSchema) {
 export function preParseString(
   zodTypeName: ZodFirstPartyTypeKind,
   data?: string
-): boolean | number | object | string | undefined {
+): boolean | number | object | string | bigint | undefined {
   if (!data) {
     return data;
   } else if (
@@ -26,6 +26,8 @@ export function preParseString(
     zodTypeName === ZodFirstPartyTypeKind.ZodArray
   ) {
     return JSON.parse(data) as boolean | number | object;
+  } else if (zodTypeName === ZodFirstPartyTypeKind.ZodBigInt) {
+    return BigInt(data);
   } else if (zodTypeName === ZodFirstPartyTypeKind.ZodString || zodTypeName === ZodFirstPartyTypeKind.ZodEnum) {
     return data;
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/server",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/packages/server/src/server-framework.ts
+++ b/packages/server/src/server-framework.ts
@@ -121,10 +121,10 @@ export class ServerOperation {
   private resultToBody(result: AnyOutputType): undefined | string | Buffer {
     if (Buffer.isBuffer(result)) {
       return result;
-    } else if (typeof result === 'number' || typeof result === 'boolean') {
+    } else if (typeof result === 'number' || typeof result === 'boolean' || typeof result === 'bigint') {
       return result.toString();
     } else if (typeof result === 'object') {
-      return JSON.stringify(result);
+      return JSON.stringify(result, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
     } else if (!result) {
       return undefined;
     }


### PR DESCRIPTION
Adds bigint support (mostly) to apimda:

1. Enable serialization/deserialization of bigint typed params and results
2. Enable serialization and *partial* deserialization of bigints in Zod/JSON

...in order to properly deserialize bigints, result schemas must be marked for Zod coercion, i.e. `z.coerce.bigint()`.  

In integration-test project, see test-controller.ts `/queryExample` output for an example.

Note that BigInt coercion in Zod uses `BigInt()`, which unlike boolean coercion, looks like it does mostly what we want and no more:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt#using_bigint_to_convert_a_number_to_a_bigint

(While apimda2 could fully support auto deserialization, it would end up doing essentially the same thing - for now IMO it's clearer to the user to specify directly.  I'm open to adding support later - it would not be a breaking change) 