### PR TITLE
fix: support z.bigint in client JSON body

### DIFF
--- a/integration-test/src/node-integration.test.ts
+++ b/integration-test/src/node-integration.test.ts
@@ -44,7 +44,7 @@ test('bodyBinaryExample', async () => {
 });
 
 test('bodyObjectExample', async () => {
-  const input = { body: { id: 100 } };
+  const input = { body: { id: 100, bInt: BigInt(Number.MAX_SAFE_INTEGER) + 2n } };
   expect(await client.bodyObjectExample(input)).toEqual(input.body);
 });
 

--- a/integration-test/src/test-controller.ts
+++ b/integration-test/src/test-controller.ts
@@ -22,9 +22,9 @@ export const testControllerDef = a.controller('/base').define({
   bodyObjectExample: a.op
     .post('/bodyObjectExample')
     .input({
-      body: a.in.body(z.object({ id: z.number() }))
+      body: a.in.body(z.object({ id: z.number(), bInt: z.coerce.bigint() }))
     })
-    .output(a.out.schema(z.object({ id: z.number() })))
+    .output(a.out.schema(z.object({ id: z.number(), bInt: z.coerce.bigint() })))
     .build(),
 
   bodyTextExample: a.op

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/client",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/packages/client/src/client-utils.ts
+++ b/packages/client/src/client-utils.ts
@@ -54,7 +54,7 @@ export function paramStringValue(value: StringifiedParamValue) {
   } else if (typeof value === 'bigint') {
     return value.toString();
   }
-  return JSON.stringify(value);
+  return JSON.stringify(value, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
 }
 
 export function paramsByLocation(definition: AnyInputDef, input: Record<string, ParamValue>) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/core",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/server",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Adds support to client to serialize BigInt as strings in JSON.

Note: apimda2 payloads are pure JSON, and thus BigInt isn't supported natively.  In order to work around this limitation, Apimda transforms all BigInt properties to strings during serialization.  However, this means that any BigInt property **must use type coercion**, i.e. `z.coerce.bigint()`.  (For query/path parameters, this isn't strictly necessary, as apimda2 handles type conversion natively, however I'd recommend using Zod coercion regardless.)