### PR TITLE
fix: make optional input parameters actually optional

### DIFF
--- a/integration-test/src/node-integration.test.ts
+++ b/integration-test/src/node-integration.test.ts
@@ -89,8 +89,7 @@ test('queryExample', async () => {
     str: 'some text',
     num: -120,
     bInt: BigInt(Number.MAX_SAFE_INTEGER) + 2n,
-    obj: { id: 0 },
-    optional: undefined
+    obj: { id: 0 }
   };
   expect(await client.queryExample(input)).toEqual(input);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,9 +62,16 @@ export type InferParamType<TParamDef, TBinary> = TParamDef extends ParamDef<infe
 
 export type AnyInputDef = Record<string, AnyParamDef>;
 
-export type InferInputType<TInputDef, TBinary> = TInputDef extends AnyInputDef
+type NotUndefinedKeys<T> = {
+  [P in keyof T]: T[P] extends Exclude<T[P], undefined> ? P : never;
+}[keyof T];
+
+export type InferRawInputType<TInputDef, TBinary> = TInputDef extends AnyInputDef
   ? { [TKey in keyof TInputDef]: InferParamType<TInputDef[TKey], TBinary> }
   : never;
+
+export type InferInputType<TInputDef, TBinary> = Partial<InferRawInputType<TInputDef, TBinary>> &
+  Pick<InferRawInputType<TInputDef, TBinary>, NotUndefinedKeys<InferRawInputType<TInputDef, TBinary>>>;
 
 // -------
 // Output


### PR DESCRIPTION
Small fix that types optional parameters as optional, not simply as a union with undefined.

See changes in integration test for details.